### PR TITLE
Remove length limitation of the binarySelector in the grammar

### DIFF
--- a/packages/Ohm-Grammars.package/OhmSmalltalk.class/class/serializedGrammar.st
+++ b/packages/Ohm-Grammars.package/OhmSmalltalk.class/class/serializedGrammar.st
@@ -153,7 +153,7 @@ baseNIntegerLiteral =
 	numberSigns? alnum+
 
 binaryMessageSelector =
-    binarySelectorChar binarySelectorChar? binarySelectorChar?
+    binarySelectorChar+
 
 binarySelectorChar =
     "~" | "!" | "@" | "%" | "&" | "*" | "-" | "+" | "=" | "|" | "\\" | "<" | ">" | "," | "?" | "/"

--- a/packages/Ohm-Grammars.package/OhmSmalltalkGrammarTest.class/instance/testGrammarParsesBinaryMessageSelectors.st
+++ b/packages/Ohm-Grammars.package/OhmSmalltalkGrammarTest.class/instance/testGrammarParsesBinaryMessageSelectors.st
@@ -1,7 +1,6 @@
-tests
 testGrammarParsesBinaryMessageSelectors
 	
 	startRule := #binaryMessageSelector.
 	self 
-		shouldParseAll: { '+' . '-' . '=' . '?' . '?!' . '@?' . '*!' . '==>' };
+		shouldParseAll: { '+' . '-' . '=' . '?' . '&' . '%' . '*' . '\\' . '<' . '>'  . '|' . '!' . '~' . ',' . '?!' . '@?' . '*!' . '==>' . '@@@@' . '====='};
 		shouldntParseAny: { '*a' . '' . 'aa' . 'a*' . 'a:' . ':a' . '+ +'}.


### PR DESCRIPTION
The implementation of the parser in Squeak 5.2 does not care about the length of binarySelectors.
That means, that you could create a method with e.g. the selector `@@@@@` and call it which results in a proper execution of the method.
Also, older versions of the `SHParserST80>>parseBinary` method do not show any limitation.