### PR TITLE
Small bugfixes

### DIFF
--- a/packages/Ohm-Core.package/OhmNode.class/instance/enclosingRule.st
+++ b/packages/Ohm-Core.package/OhmNode.class/instance/enclosingRule.st
@@ -3,6 +3,7 @@ enclosingRule
 
 	| aParent |
 	aParent := self parent.
+	aParent ifNil: [ ^ self ].
 	[aParent ruleName = OhmParsingExpression listRuleIdentifier] whileTrue: [
 		aParent := aParent parent].
 	^ aParent

--- a/packages/Ohm-Core.package/OhmNode.class/methodProperties.json
+++ b/packages/Ohm-Core.package/OhmNode.class/methodProperties.json
@@ -6,7 +6,7 @@
 		"calculateSourceMap" : "pre 7/13/2020 10:41",
 		"children" : "pre 1/5/2015 16:06",
 		"children:" : "pre 1/5/2015 16:06",
-		"enclosingRule" : "pre 7/13/2020 11:20",
+		"enclosingRule" : "fau 7/16/2020 16:17",
 		"grammar" : "pre 1/5/2015 15:38",
 		"grammar:" : "pre 1/5/2015 15:38",
 		"initialize" : "pre 11/21/2017 15:29",

--- a/packages/Ohm-Core.package/OhmSourceMapping.class/instance/terminalExpression..st
+++ b/packages/Ohm-Core.package/OhmSourceMapping.class/instance/terminalExpression..st
@@ -1,5 +1,6 @@
 standard attributes
 terminalExpression: aNode
 
-	aNode interval start to: aNode interval end do: [:i |
-		(self sourceMap at: i) add: aNode]
+	aNode interval start
+		to: (aNode interval end min: self sourceMap size)
+		do: [:i | (self sourceMap at: i) add: aNode]

--- a/packages/Ohm-Core.package/OhmSourceMapping.class/methodProperties.json
+++ b/packages/Ohm-Core.package/OhmSourceMapping.class/methodProperties.json
@@ -6,4 +6,4 @@
 		"defaultExpression:" : "pre 7/13/2020 11:02",
 		"sourceMap" : "pre 4/29/2020 10:20",
 		"sourceMap:" : "pre 4/29/2020 10:20",
-		"terminalExpression:" : "pre 7/13/2020 11:01" } }
+		"terminalExpression:" : "fau 7/14/2020 15:24" } }


### PR DESCRIPTION
We wrote two bugfixes so that the prototype works for our project. We know that our solutions are hacky but we haven't had time to come up with a better solution yet.
- In order to ignore invalid intervals (I described the problem [here](https://github.com/hpi-swa/Ohm-S/issues/47#issuecomment-658105868)) and prevent index out of bound exceptions, we only fill the source map until its end.
- Because the root node's parent is `nil`, the message `enclosingRule` does not work: `Undefined Object does not understand ruleName`. We added a nil check to prevent this error from happening.