### PR TITLE
Fix spelling of Metacello path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ohm/S is a Squeak/Smalltalk implementation of the metaprogramming framework [Ohm
 ```Smalltalk
 Metacello new
   baseline: 'Ohm';
-  repository: 'github://hpi-swa/ohm-s/packages';
+  repository: 'github://hpi-swa/Ohm-S/packages';
   load.
 ```
 


### PR DESCRIPTION
Complements tom95/sandblocks#47. See Metacello/metacello#542 for more information.